### PR TITLE
fix: use target_ip from settings.json to debug

### DIFF
--- a/docs/vscode.rst
+++ b/docs/vscode.rst
@@ -449,7 +449,7 @@ Now, lets configure the tasks that tell VSCode how to build and deploy our appli
             {
                 "label": "Kill GDBServer on Target",
                 "type": "shell",
-                "command": "ssh root@${input:target_ip} 'killall -q gdbserver || true'",
+                "command": "ssh root@${config:target_ip} 'killall -q gdbserver || true'",
                 "problemMatcher": []
             }
         ]


### PR DESCRIPTION
The task to kill the remote gdbserver used an `input` parameter for the target ip, instead of the `config` parameter to get it from the `settings.json`, which cases an error when debugging is launched.